### PR TITLE
Fix: responsive chart resizing with ResizeObserver

### DIFF
--- a/dashboard/static/components/charts.js
+++ b/dashboard/static/components/charts.js
@@ -1,5 +1,20 @@
 // Chart helper functions using ECharts
 
+/**
+ * Observe the chart container for size changes and auto-resize the ECharts instance.
+ * Uses ResizeObserver so charts respond to CSS grid/flex reflows, not just window resize.
+ */
+function observeChartResize(chart, elementId) {
+    const container = document.getElementById(elementId);
+    if (!container) return;
+    const ro = new ResizeObserver(() => {
+        chart.resize();
+    });
+    ro.observe(container);
+    // Also handle dispose to avoid leaks
+    chart.on('disposed', () => ro.disconnect());
+}
+
 const CHART_COLORS = [
     '#E94560', '#4285F4', '#0F9D58', '#F4B400', '#9C27B0',
     '#FF6F00', '#00BCD4', '#8BC34A', '#FF5722', '#673AB7'
@@ -50,7 +65,7 @@ function createDonutChart(elementId, data, title) {
     };
     
     chart.setOption(option);
-    window.addEventListener('resize', () => chart.resize());
+    observeChartResize(chart, elementId);
     return chart;
 }
 
@@ -97,7 +112,7 @@ function createBarChart(elementId, categories, data, title) {
     };
     
     chart.setOption(option);
-    window.addEventListener('resize', () => chart.resize());
+    observeChartResize(chart, elementId);
     return chart;
 }
 
@@ -142,7 +157,7 @@ function createStackedBarChart(elementId, categories, series, title) {
     };
     
     chart.setOption(option);
-    window.addEventListener('resize', () => chart.resize());
+    observeChartResize(chart, elementId);
     return chart;
 }
 
@@ -187,7 +202,7 @@ function createLineChart(elementId, categories, series, title) {
     };
     
     chart.setOption(option);
-    window.addEventListener('resize', () => chart.resize());
+    observeChartResize(chart, elementId);
     return chart;
 }
 
@@ -231,7 +246,7 @@ function createSankeyChart(elementId, nodes, links, title) {
     };
     
     chart.setOption(option);
-    window.addEventListener('resize', () => chart.resize());
+    observeChartResize(chart, elementId);
     return chart;
 }
 
@@ -277,7 +292,7 @@ function createHorizontalBarChart(elementId, categories, data, title) {
     };
     
     chart.setOption(option);
-    window.addEventListener('resize', () => chart.resize());
+    observeChartResize(chart, elementId);
     return chart;
 }
 
@@ -326,6 +341,6 @@ function createStackedAreaChart(elementId, categories, series, title) {
     };
     
     chart.setOption(option);
-    window.addEventListener('resize', () => chart.resize());
+    observeChartResize(chart, elementId);
     return chart;
 }

--- a/dashboard/static/styles.css
+++ b/dashboard/static/styles.css
@@ -178,6 +178,7 @@ body {
     width: 100%;
     height: 400px;
     min-height: 400px;
+    overflow: hidden;
 }
 
 .chart-container.large {


### PR DESCRIPTION
## Problem
Charts don't resize dynamically on window/layout changes and get clipped. The existing code uses `window.addEventListener('resize')` which only fires on window resize — it misses CSS grid/flex reflows (e.g. when media query breakpoints change column layouts).

## Fix
- Added `observeChartResize()` helper using `ResizeObserver` on each chart's container element
- Replaced all 7 `window.addEventListener('resize', ...)` calls with the new helper
- Added `overflow: hidden` to `.chart-container` to prevent clipping during transitions
- `ResizeObserver` disconnects on chart dispose to avoid memory leaks

## Testing
- Resize browser window across breakpoints (1200px, 1024px, 768px)
- Charts should smoothly adapt without clipping

Fixes #6