### PR TITLE
Fix: layout overflow clipping on main content and grid children

### DIFF
--- a/dashboard/static/styles.css
+++ b/dashboard/static/styles.css
@@ -91,6 +91,8 @@ body {
 .main-content {
     margin-left: 240px;
     flex: 1;
+    min-width: 0;
+    overflow-x: hidden;
     padding: 2rem 3rem;
 }
 
@@ -132,7 +134,7 @@ body {
 /* Summary Cards Grid */
 .summary-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
     gap: 1rem;
     margin-bottom: 1.5rem;
 }
@@ -344,6 +346,10 @@ button, .btn {
 .grid {
     display: grid;
     gap: 1.5rem;
+}
+
+.grid > * {
+    min-width: 0;
 }
 
 .grid-2 {


### PR DESCRIPTION
## Problem
Summary cards and grid children (tables) were getting clipped at the right edge — the 4th summary card and 'Top Merchants' TOTAL column were cut off (see screenshot in thread).

## Root Cause
`.main-content` is a flex child with `margin-left: 240px` but no `min-width: 0` — CSS flex items default to `min-width: auto` which prevents shrinking below content size. Same issue on `.grid` children.

## Fix
- `.main-content`: added `min-width: 0` + `overflow-x: hidden`
- `.grid > *`: added `min-width: 0`
- `.summary-grid`: reduced `minmax(220px, 1fr)` → `minmax(180px, 1fr)` so 4 cards fit at typical widths

## Verified
- 1200px: 4 cards in a row, no clipping ✅
- 900px: cards wrap 2×2, grids stack, charts resize ✅
- Resize transitions smooth ✅

Part of #6