### PR TITLE
Fix transaction amount colors: green for income, red for expenses

### DIFF
--- a/dashboard/static/reports.html
+++ b/dashboard/static/reports.html
@@ -379,7 +379,7 @@
                                             ${txn.category ? `<span class="badge category transaction-category-badge">${txn.category}</span>` : ''}
                                         </div>
                                     </div>
-                                    <div class="transaction-amount">${formatCurrency(txn.amount)}</div>
+                                    <div class="transaction-amount ${txn.amount >= 0 ? 'positive' : ''}">${formatCurrency(txn.amount)}</div>
                                 </div>
                             `;
                         });

--- a/dashboard/static/review.html
+++ b/dashboard/static/review.html
@@ -128,6 +128,10 @@
             flex-shrink: 0;
         }
 
+        .transaction-amount.positive {
+            color: var(--green);
+        }
+
         .transaction-details {
             font-size: 0.875rem;
             color: var(--gray-text);
@@ -556,7 +560,7 @@
                         <div class="transaction-main">
                             <div class="transaction-header">
                                 <div class="transaction-merchant">${merchant}</div>
-                                <div class="transaction-amount">$${Math.abs(txn.amount).toFixed(2)}</div>
+                                <div class="transaction-amount ${txn.amount >= 0 ? 'positive' : ''}">$${Math.abs(txn.amount).toFixed(2)}</div>
                             </div>
                             <div class="transaction-details">
                                 ${formatDate(txn.transaction_date)} • ${txn.account_id || 'Unknown account'}

--- a/dashboard/static/styles.css
+++ b/dashboard/static/styles.css
@@ -785,6 +785,10 @@ button, .btn {
     white-space: nowrap;
 }
 
+.transaction-amount.positive {
+    color: var(--green);
+}
+
 /* Summary Sidebar */
 .summary-sidebar {
     background: var(--white);


### PR DESCRIPTION
The `.transaction-amount` class was hardcoded to coral/red for all transactions. Added a `.positive` modifier class that shows green for income (amount >= 0).

**Changes:**
- `styles.css`: Added `.transaction-amount.positive` rule
- `reports.html`: Conditionally apply `.positive` class based on amount
- `review.html`: Same fix + added inline style override

Fixes #14