### PR TITLE
fix: Missing comma in chart tooltip config

### DIFF
--- a/dashboard/static/cashflow.html
+++ b/dashboard/static/cashflow.html
@@ -38,7 +38,7 @@
     </div>
 
     <script src="/static/components/sidebar.js"></script>
-    <script src="/static/components/charts.js?v=3"></script>
+    <script src="/static/components/charts.js?v=4"></script>
     <script>
         async function setCurrentMonth() {
             // Find latest month with data

--- a/dashboard/static/components/charts.js
+++ b/dashboard/static/components/charts.js
@@ -212,7 +212,7 @@ function createLineChart(elementId, categories, series, title) {
             textStyle: { fontSize: 16, fontWeight: 600, color: '#1A1A2E' }
         },
         tooltip: {
-            trigger: 'axis'
+            trigger: 'axis',
             confine: true,
         },
         legend: {

--- a/dashboard/static/index.html
+++ b/dashboard/static/index.html
@@ -129,7 +129,7 @@
     </div>
 
     <script src="/static/components/sidebar.js"></script>
-    <script src="/static/components/charts.js?v=3"></script>
+    <script src="/static/components/charts.js?v=4"></script>
     <script src="/static/components/table.js"></script>
     <script>
         // Load YTD overview

--- a/dashboard/static/reports.html
+++ b/dashboard/static/reports.html
@@ -123,7 +123,7 @@
     </div>
 
     <script src="/static/components/sidebar.js"></script>
-    <script src="/static/components/charts.js?v=3"></script>
+    <script src="/static/components/charts.js?v=4"></script>
     <script>
         // State
         let currentTab = 'cashflow';


### PR DESCRIPTION
Syntax error from sed insertion — missing comma before confine:true on non-pie charts.