### PR TITLE
fix: Remove redundant center label on mobile donuts

### DIFF
--- a/dashboard/static/cashflow.html
+++ b/dashboard/static/cashflow.html
@@ -38,7 +38,7 @@
     </div>
 
     <script src="/static/components/sidebar.js"></script>
-    <script src="/static/components/charts.js?v=4"></script>
+    <script src="/static/components/charts.js?v=5"></script>
     <script>
         async function setCurrentMonth() {
             // Find latest month with data

--- a/dashboard/static/components/charts.js
+++ b/dashboard/static/components/charts.js
@@ -71,7 +71,7 @@ function createDonutChart(elementId, data, title) {
             labelLine: { show: false },
             emphasis: {
                 label: {
-                    show: true,
+                    show: !isMobile,
                     position: 'center',
                     fontSize: isMobile ? 12 : 14,
                     fontWeight: 'bold',
@@ -446,7 +446,7 @@ function createDonutWithCenterLabel(elementId, data, centerLabel, title) {
             labelLine: { show: false },
             emphasis: {
                 label: {
-                    show: true,
+                    show: !isMobile,
                     position: 'center',
                     fontSize: isMobile ? 12 : 14,
                     fontWeight: 'bold',

--- a/dashboard/static/index.html
+++ b/dashboard/static/index.html
@@ -129,7 +129,7 @@
     </div>
 
     <script src="/static/components/sidebar.js"></script>
-    <script src="/static/components/charts.js?v=4"></script>
+    <script src="/static/components/charts.js?v=5"></script>
     <script src="/static/components/table.js"></script>
     <script>
         // Load YTD overview

--- a/dashboard/static/reports.html
+++ b/dashboard/static/reports.html
@@ -123,7 +123,7 @@
     </div>
 
     <script src="/static/components/sidebar.js"></script>
-    <script src="/static/components/charts.js?v=4"></script>
+    <script src="/static/components/charts.js?v=5"></script>
     <script>
         // State
         let currentTab = 'cashflow';


### PR DESCRIPTION
Tooltip already shows full info on tap. Center emphasis label is redundant and clutters the chart.